### PR TITLE
Changes to sections 3.2 and 3.3

### DIFF
--- a/chapter00-valeurs-propres.tex
+++ b/chapter00-valeurs-propres.tex
@@ -295,13 +295,13 @@ Soit $p_A(λ) = a_0 + a_1 λ + \cdots + a_n λ^n$ le polynôme caractéristique 
 
 \begin{remark}
   \label{rem:6}
-  Pour deux bases $B$ et $B'$, des que $A_{B} =  P_{BB'}^{-1} A_{B'}  P_{BB'}$, alors
+  Pour deux bases $B$ et $B'$, comme on a $A_{B} =  P_{BB'}^{-1} A_{B'}  P_{BB'}$, alors
   \begin{eqnarray*}
     \det(A_B - λI_n) & = & \det(P_{BB'}^{-1} A_{B'}  P_{BB'} - λP_{BB'}^{-1}I_n  P_{BB'}) \\
                      & = & \det(P_{BB'}^{-1}) \det(A_{B' }- λI_n) \det(P_{BB'}) \\
-     & = & \det(A_{B' }- λI_n),
+     & = & \det(A_{B' }- λI_n).
   \end{eqnarray*}
-  La définition~\ref{def:50} ne dépend donc pas de la base choisie et a donc un sens.
+  La définition~\ref{def:50} ne dépend ainsi pas de la base choisie et a donc un sens.
 \end{remark}
 
 
@@ -326,7 +326,7 @@ B =     \{ v_1,\dots,v_m, w_1,\dots,w_{n-m}\}
     \end{displaymath}
     de $V$.
 
-    La matrice $A_B$ est alors de la forme
+    La matrice $A_B$ de l'endomorphisme $f$ dans la base $B$ est alors de la forme
     \begin{displaymath}
       A_B =
       \begin{pmatrix}
@@ -334,7 +334,7 @@ B =     \{ v_1,\dots,v_m, w_1,\dots,w_{n-m}\}
         0 & D
       \end{pmatrix}
     \end{displaymath}
-    où $C ∈ K^{m × n-m}$ et $D ∈ K^{(n-m) ×(n-m)}$. En effet, on a par définition $A_B[v_i]_{B} = [A_B v_i]_{B}$. Par conséquent, $A_B e_i = \lambda e_i$, où $e_i$ est le $i$-ème vecteur canonique de dimension $n$.
+    où $C ∈ K^{m × n-m}$ et $D ∈ K^{(n-m) ×(n-m)}$. En effet, on a par définition $A_B[v_i]_{B} = [f(v_i)]_{B}$, et par conséquent $A_B e_i = \lambda e_i$, où $e_i$ est le $i$-ème vecteur canonique de dimension $n$.
     
     Lorsqu'on développe le déterminant d'une matrice en blocs comme $A_B$ grâce à la formule de Leibniz, seules les permutations envoyant $\{1, \dots, m\}$ et $\{m+1, \dots, n\}$ sur eux-même donnent un produit non nul. On peut alors diviser la somme en deux pour obtenir que le déterminant est exactement le produit des déterminants des blocs diagonaux.
     Le polynôme caractéristique $p(x) ∈ K[x]$ de $f$ est alors

--- a/chapter01-produits-scalaires.tex
+++ b/chapter01-produits-scalaires.tex
@@ -1108,7 +1108,7 @@ en recourant à l'inégalité de Cauchy-Schwarz.
 \begin{displaymath}
   v - a_1v_1- \cdots - a_n v_n\, % \text{ où  }\, a_i \in ℝ 
 \end{displaymath}
-est perpendiculaire à tous $v_1,\dots,v_n$ si et seulement si $a_i$ est la composante de $v$ sur $v_i$, i.e. $a_i=  \pscal{v,v_i}/ \pscal{v_i,v_i}$ pour tout $i$. 
+est perpendiculaire à tous les $v_1,\dots,v_n$ si et seulement si $a_i$ est la composante de $v$ sur $v_i$, c'est-à-dire $a_i=  \pscal{v,v_i}/ \pscal{v_i,v_i}$ pour tout $i$. 
 \end{lemma}
 
 \begin{proof}
@@ -1402,7 +1402,7 @@ vecteurs deux à deux orthogonaux.
       1 & 0 & \cdots &\cdots & 0 & 1
     \end{pmatrix}
   \end{displaymath}
-\item Trouver une forme bilinéaire symétrique de $\R^n$ tel qu'il existe des vecteurs $u,v \in \R^n$ avec $\pscal{u,u}<0$ et $\pscal{v,v}>0$. 
+\item Trouver une forme bilinéaire symétrique de $\R^n$ telle qu'il existe des vecteurs $u,v \in \R^n$ avec $\pscal{u,u}<0$ et $\pscal{v,v}>0$. 
 \item Soit $V$ un espace vectoriel sur $\R$ muni d'une forme bilinéaire symétrique. S'il existe des vecteurs $u,v \in V$ tels que $\pscal{u,u}<0$ et $\pscal{v,v}>0$, il existe un vecteur $w \neq 0$ tel que $\pscal{w,w}=0$. 
 \item Montrer que l'inégalité de Bessel (Théorème \ref{thr:4}) est une égalité si $v$ est dans le sous-espace engendré par les $v_1,\dots,v_n$. 
 \item On considère l'espace euclidien des fonctions continues sur l'intervalle $[0,1]$ muni de la forme bilinéaire symétrique 

--- a/chapter01-produits-scalaires.tex
+++ b/chapter01-produits-scalaires.tex
@@ -749,7 +749,7 @@ Alors on trouve  $P ∈ ℝ^{n ×n}$ inversible telle que
   Pour un espace vectoriel sur $ℝ$ de dimension finie, on appelle une base $B$ de $V$ telle que $A_B^{\pscal{,}}$ a la forme décrite en~\eqref{eq:5} une \emph{base de Sylvester}. 
 \end{definition}
 
-Nous allons maintenant démontrer, que les nombres $r$ et $s$ sont invariants par rapport à la base $B$ de $V$. 
+Nous allons maintenant démontrer, que les nombres $r$ et $s$ sont invariants par rapport au choix de la base $B$ de $V$. 
 
 
 \begin{definition}
@@ -766,11 +766,11 @@ Nous allons maintenant démontrer, que les nombres $r$ et $s$ sont invariants pa
   muni d'une forme bilinéaire symétrique. Soit $B = \{v_1,\dots,v_n\}$
   une base orthogonale de $V$.
   La dimension $\dim(V_0)$
-  est égale au nombre d'index $i$ tel que $\pscal{v_i,v_i}=0$.
+  est égale au nombre d'indices $i$ tel que $\pscal{v_i,v_i}=0$.
 \end{theorem}
 
 \begin{proof}
-  Nous utilisons la notation d'en-dessus et écrivons 
+  Nous utilisons la notation d'au-dessus et écrivons 
   \begin{displaymath}
     \pscal{v,x} =   [v]_B^T
                     \begin{pmatrix}
@@ -782,7 +782,9 @@ Nous allons maintenant démontrer, que les nombres $r$ et $s$ sont invariants pa
 Cette expression est égale à zéro pour tout $x ∈V$  si et seulement si $\left([v]_B\right)_i = 0$ pour tout $i$ tel que $c_i \neq 0$. Ceci démontre que $\{ v_i \colon \pscal{v_i,v_i}=0\}$ est une base de l'espace de nullité. 
 \end{proof}
 
-
+\begin{definition}
+  La dimension de l'espace de nullité $\dim(V_0)$ est appelé l'\emph{indice de nullité} de la forme bilinéaire symétrique. 
+\end{definition}
 
 \begin{theorem}[Théorème de Sylvester] 
 \label{thr:10}
@@ -822,11 +824,11 @@ Il existe un nombre entier $r ≥0$ tel que, pour chaque base orthogonale
   \begin{displaymath}
     x_1 v_1 + \cdots + x_r v_r = y_{r'+1} w_{r'+1} + \cdots y_n w_n 
   \end{displaymath}
-et ça implique, dès que les $v_i$ et respectivement les $w_i$  sont orthogonaux, 
+et ça implique, car les $v_i$ et respectivement les $w_i$  sont orthogonaux entre eux, 
 \begin{displaymath}
    x_1^2\pscal{v_1,v_1} + \cdots + x_r^2 \pscal{v_r,v_r} = y_{r'+1}^2 \pscal{w_{r'+1},w_{r'+1}} + \cdots y_n^2 \pscal{w_n,w_n} 
 \end{displaymath}
-Les $\pscal{v_i,v_i}$ à gauche sont strictement positifs. Les $\pscal{w_i,w_i} $ à droite sont non positifs. Alors $x_1=0,\dots,x_r = 0$ et dès que les $w_i$ sont linéairement indépendants, on a $y_{r'+1}=0,\dots,y_n=0$. 
+Les $\pscal{v_i,v_i}$ à gauche sont strictement positifs. Les $\pscal{w_i,w_i} $ à droite sont négatifs ou nuls. Il suit que $x_1=0,\dots,x_r = 0$ et, comme les $w_i$ sont linéairement indépendants, on a également $y_{r'+1}=0,\dots,y_n=0$. 
 \end{proof}
 
 
@@ -893,6 +895,7 @@ Les colonnes de $P$ sont une base du Sylvester.
 \subsection*{Exercices} 
 
 \begin{enumerate}
+\item Démontrer, à l'aide des théorèmes \ref{thr:9} et \ref{thr:10}, que l'indice de négativité (l'entier $s$ de l'équation \eqref{eq:29}) ne dépend lui aussi pas de la base choisie.
 \item Déterminer l'indice de nullité et l'indice de positivité des 
 formes bilinéaire symétriques 
  définies par les matrices suivantes

--- a/chapter01-produits-scalaires.tex
+++ b/chapter01-produits-scalaires.tex
@@ -489,13 +489,13 @@ Est-ce que $\spa\{v_1,v_2,v_3\}$ possède une base orthogonale par rapport à la
 \begin{displaymath}
   A = P^T B P.
 \end{displaymath}
-Nous écrivons $A \cong B$. 
+Nous écrivons dans ce cas $A \cong B$. 
 \end{definition}
 
 
 \begin{example}
   \label{exe:22}
-  Si $V$ est de dimension finie et $B,B'$ sont deux bases, \eqref{eq:28} montrer que $A_B^{\pscal{,}} \cong A_{B'}^{\pscal{,}}$. 
+  Si $V$ est de dimension finie et $B,B'$ sont deux bases de V, la relation \eqref{eq:28} montre que $A_B^{\pscal{,}} \cong A_{B'}^{\pscal{,}}$. 
 \end{example}
 
 \begin{lemma}
@@ -511,27 +511,27 @@ Nous écrivons $A \cong B$.
 Le relation entre $\cong$ et le concept de l'orthogonalité   est précisée dans le lemme suivant. 
 \begin{lemma}
 \label{thr:13}
-  Soit $B = \{v_1,\dots,v_n\}$ une base de $V$. $V$ possède une base orthogonale si et seulement s'il existe une matrice diagonale $D$ 
+  Soit $V$ un espace vectoriel de dimension finie et $B = \{v_1,\dots,v_n\}$ une base quelconque. Alors $V$ possède une base orthogonale si et seulement s'il existe une matrice diagonale $D$ 
 telle que 
  $A_B^{\pscal{.}} \cong D$. 
 \end{lemma}
 \begin{proof}
-Si $B'$ est une base orthogonale de $V$, alors $A_{B'}^{〈,〉}$ est une base diagonale. Des qu'on a \eqref{eq:28}, alors $A_{B}^{〈,〉}$ est congruente à une matrice diagonale. 
+Si $B'$ est une base orthogonale de $V$, alors $A_{B'}^{〈,〉}$ est une base diagonale. Grâce à la relation \eqref{eq:28}, $A_{B}^{〈,〉}$ est congruente à une matrice diagonale. 
 
 
 Si $A_B^{\pscal{.}} \cong D$ où $D ∈ K^{n×n}$ est une matrice diagonale, alors 
-il existe une matrice $P ∈K^{n ×n}$ inversible, tel que 
+il existe une matrice $P ∈K^{n ×n}$ inversible, telle que 
 \begin{displaymath}
   P^T A_B^{\pscal{.}} P = D. 
 \end{displaymath}
-La base  $B' = \{w_1,\dots,w_n\}$ donnée par 
+La base  $B' = \{w_1,\dots,w_n\}$ donnée par les colonnes de $P$ (en tant que coordonées dans la base $B$) :
   \begin{displaymath}
      [w_j]_B =
   \begin{pmatrix}
-    p_{1j}\\ \vdots \\ p_{nj}
-  \end{pmatrix},
+    p_{1j}\\ \vdots \\ p_{nj} 
+  \end{pmatrix} \iff w_j = \sum_{i=1}^n p_{ij} v_i, \quad \forall j=1, \dots, n,
   \end{displaymath}
-donc $w_j = \sum_{i=1}^n p_{ij} v_i$, est une base orthogonale. 
+ est donc une base orthogonale. 
 \end{proof}
 
 
@@ -578,22 +578,24 @@ Maintenant, nous allons formaliser la procédé appliquée dans example~\ref{exe
       & & & &  b_{n,i} & \dots & b_{n,n} \\      
     \end{pmatrix}
   \end{equation}
-où les composantes des premières $(i-1)$ lignes et colonnes sont zéro sauf pour la composante sur la diagonale de la matrice. 
+où les composantes des premières $(i-1)$ lignes et colonnes sont nulles sauf éventuellement sur la diagonale. 
 
 \medskip 
 \noindent 
-Pour $1 \leq i \leq n$, la \emph{$i$-ème itération}  est comme suit. 
+Pour $1 \leq i \leq n$, la \emph{$i$-ème itération} procède comme suit. 
 \begin{itemize}
- \item S'il existe un index $j≥i$ tel que $b_{jj} \neq 0$ soit $j ≥i$ le plus petit tel indexe et  échange la $i$-ème ligne et la $j$-ème ligne et après    la $i$-ème colonne et la $j$-ème colonne. 
-\item Si $b_{ii}=0$, soit $j \in \{i+1,\dots,n\}$ tel que $b_{ij} \neq 0$. 
-  Si un tel indexe n'existe pas on procède à la $i+1$-ème itération. 
-  On additionne la ligne $j$ sur la ligne $i$ et on additionne la colonne $j$ sur la colonne $i$. Étant donné que $\car(K) \neq 2$, on a alors maintenant $b_{ii} = 2 ⋅ b_{i,j} \neq 0$. 
-\item Pour chaque $j \in \{i+1,\dots,n\}$:  on additionne $-b_{ij}/b_{ii}$ fois la $i$-ème ligne sur la $j$-ème ligne et on additionne $-b_{ij}/b_{ii}$ fois la $i$-ème colonne sur la $j$-ème colonne. 
+ \item Soit l'indice $k$ minimal tel que $k \geq i$ et $b_{kk} \neq 0$. On échange la $i$-ème ligne et la $k$-ème ligne puis la $i$-ème colonne et la $k$-ème colonne. Ceci permet (entre autres) d'échanger les coefficients $b_{ii}$ et $b_{kk}$ de la diagonale, s'assurant ainsi d'avoir un coefficient non nul. 
+ 
+ \item Si l'indice $k$ de l'étape précédente n'existe pas (tous les coefficients diagonaux après $c_{i-1}$ sont nuls), soit $j \in \{i+1,\dots,n\}$ un indice vérifiant $b_{ij} \neq 0$. On ajoute la $j$-ème ligne à la $i$-ème ligne puis la $j$-ème colonne à la $i$-ème colonne. Le $i$-ème coefficient de la diagonale devient alors $2 b_{ij} + b_{jj} = 2 b_{ij} \neq 0$.
+ 
+ \item Si, à son tour, un tel indice $j$ n'existe pas, on peut procéder à la $i+1$-ème itération car la matrice est déjà de la forme \eqref{eq:7} (avec $i+1$ à la place de $i$).
+  
+\item Pour chaque $j \in \{i+1,\dots,n\}$:  on additionne $-b_{ij}/b_{ii}$ fois la $i$-ème ligne sur la $j$-ème ligne et on additionne $-b_{ij}/b_{ii}$ fois la $i$-ème colonne sur la $j$-ème colonne. Ceci permet d'annuler les coefficients à droite et sous le coefficient $b_{ii}$. On peut alors poursuivre à l'étape $i+1$.
 \end{itemize}    
 
+Remarquons que chaque opération est faite à la fois sur les lignes et sur les colonnes. Ceci garantit que la matrice résultante reste symétrique. De plus, les opérations sont faites sur les lignes et colonnes d'indices $j \geq i$, laissant intacte la forme de la matrice \eqref{eq:7}.
 
 \end{algorithm}
-
 
 
 \begin{example}
@@ -619,7 +621,7 @@ En utilisant notre algorithme on trouve
 0 & 0 & 1
   \end{pmatrix}
 \end{displaymath}
-tel que 
+telle que 
 \begin{displaymath}
   P^T \cdot A^{\pscal{.}}_B \cdot P =
   \begin{pmatrix}
@@ -647,7 +649,7 @@ Alors $B' = \{v_1,v_2,-2v_1 -(4/3) v_2 + v_3\}$ est une base orthogonale de $V$.
       0 & 1 & 0 
     \end{pmatrix} \in \Z_2^{3\times 3} 
   \end{displaymath}
-  est congruente à une matrice diagonale? \emph{Renseignement: voir l'exercice~\ref{item:1}. de la section~\ref{sec:orthogonalite}.}  
+  est congruente à une matrice diagonale? \emph{Indice : voir l'exercice~\ref{item:1}. de la section~\ref{sec:orthogonalite}.}  
 \item Soit $V$ un espace vectoriel  sur un corps $K$ de dimension finie muni d'une forme bilinéaire symétrique $\pscal{.}$. Soit $B = \{v_1,\dots,v_n\}$ une base de $V$. Montrer que $A_B^{\pscal{.}} \in K^{n \times n}$ est congruente à une matrice diagonale si  et seulement si $V$ possède une base orthogonale. 
 
 \item Soit $K$ un corps de caractéristique $2$ et soit $V$ un espace vectoriel sur $K$ de dimension finie muni d'une forme bilinéaire symétrique non-nulle.  Soit 
@@ -676,25 +678,6 @@ Alors $B' = \{v_1,v_2,-2v_1 -(4/3) v_2 + v_3\}$ est une base orthogonale de $V$.
   \end{enumerate}
 \item Modifier l'algorithme~\ref{alg:1} tel qu'il soit aussi correct pour des corps de caractéristique $2$.  Soit l'algorithme découvre que la matrice symétrique $A \in K^{n \times n}$ n'est pas congruente à une matrice diagonale, soit l'algorithme calcule une matrice diagonale congruente à $A$. 
 \item Comment peut-on déterminer si un espace vectoriel de dimension finie muni d'une forme bilinéaire symétrique  possède une base orthogonale? Décrire très brièvement une méthode. 
-\item Déterminer l'indice de nullité et l'indice de positivité des 
-formes bilinéaire symétriques 
- définies par les matrices suivantes
-  \begin{displaymath}
-    \begin{pmatrix}
-      1 & 2 \\
-      2 & -1
-    \end{pmatrix}
-    , \,
-    \begin{pmatrix}
-      1 & 1 \\
-      1 & 1
-    \end{pmatrix}, \, 
-    \begin{pmatrix}
-      2 & 4 & 2 \\
-      4 & 3 &  1 \\ 
-      2 & 1 &1
-    \end{pmatrix}. 
-  \end{displaymath}
  
 \item Soit $V$ un espace euclidien de dimension $n$. Montrer que $V$ possède une base $B$ telle que pour tout $x,y \in V$
   \begin{displaymath}
@@ -910,6 +893,26 @@ Les colonnes de $P$ sont une base du Sylvester.
 \subsection*{Exercices} 
 
 \begin{enumerate}
+\item Déterminer l'indice de nullité et l'indice de positivité des 
+formes bilinéaire symétriques 
+ définies par les matrices suivantes
+  \begin{displaymath}
+    \begin{pmatrix}
+      1 & 2 \\
+      2 & -1
+    \end{pmatrix}
+    , \,
+    \begin{pmatrix}
+      1 & 1 \\
+      1 & 1
+    \end{pmatrix}, \, 
+    \begin{pmatrix}
+      2 & 4 & 2 \\
+      4 & 3 &  1 \\ 
+      2 & 1 &1
+    \end{pmatrix}. 
+  \end{displaymath}
+
 \item Soit $V$ un espace vectoriel de dimension finie sur $\R$ et soit $\pscal{.}$ une forme bilinéaire symétrique  sur $V$.  Montrer que $V$ admet une décomposition en somme directe 
   \begin{displaymath}
     V_0 \oplus V^+ \oplus V^-
@@ -923,7 +926,6 @@ et
   \pscal{v,v} <0 \text{ pour tout } v \in V^- \setminus\{0\}. 
 \end{displaymath}
 \end{enumerate}
-
 
 
 


### PR DESCRIPTION
Most importantly : 
Rewrote the diagonalization algorithm; hopefully it's clearer (still open to changes..)
I added an exercise to prove that the index of negativity is also invariant under choice of basis. This is motivated by the remark after def 3.6 (def:37), and a sketch was done in class.

Maybe exercises 5 and 6 of section 3.4 should be moved to section 3.3?