### PR TITLE
small typo chapter "Formes bilinéaires"

### DIFF
--- a/chapter01-produits-scalaires.tex
+++ b/chapter01-produits-scalaires.tex
@@ -212,7 +212,7 @@ qui est égale a $1$. Alors $f(v,b_i) \neq 0$. Donc $f$ est non dégénérée à
   \end{enumerate}
   
   \noindent
-  Des que $0 ∈ E^\perp  $, on a que $E^\perp≠ ∅$.  
+  Des que $0 ∈ E^\perp  $, on a que $E^\perp≠ ∅$.  %ici E^\perp \neq \varnothing peur résoudre le problème a la compilation : l'ensemble vide est affiché deux fois ...
   Si $u,v \in E^\perp$ alors pour tout $e \in E$ 
   \begin{displaymath}
 %    \pscal{e,u+v} = \pscal{e,u} + \pscal{e,-v} = 0 + 0 = 0,

--- a/chapter01-produits-scalaires.tex
+++ b/chapter01-produits-scalaires.tex
@@ -62,7 +62,7 @@ On appelle cette forme bilinéaire la \emph{forme bilinéaire standard} de $K^n$
 
 \begin{example}
   \label{exe:31}
-  Soit $V = ℝ^r$ et
+  Soit $V = ℝ^3$ et
   \begin{displaymath}
     \pscal{u,v} = u^T
     \begin{pmatrix}


### PR DESCRIPTION
I am really not sure about this one. But I didn't see why it should be r and not 3.