### PR TITLE
Update chapter01-produits-scalaires.tex

### DIFF
--- a/chapter01-produits-scalaires.tex
+++ b/chapter01-produits-scalaires.tex
@@ -516,7 +516,7 @@ telle que
  $A_B^{\pscal{.}} \cong D$. 
 \end{lemma}
 \begin{proof}
-Si $B'$ est une base orthogonale de $V$, alors $A_{B'}^{〈,〉}$ est une base diagonale. Grâce à la relation \eqref{eq:28}, $A_{B}^{〈,〉}$ est congruente à une matrice diagonale. 
+Si $B'$ est une base orthogonale de $V$, alors $A_{B'}^{〈,〉}$ est une matrice diagonale. Grâce à la relation \eqref{eq:28}, $A_{B}^{〈,〉}$ est congruente à une matrice diagonale. 
 
 
 Si $A_B^{\pscal{.}} \cong D$ où $D ∈ K^{n×n}$ est une matrice diagonale, alors 


### PR DESCRIPTION
$A_{B'}^{〈,〉}$ est une matrice et non une base.