### PR TITLE
Update chapter03-systemes-differentiels-lineaires.tex

### DIFF
--- a/chapter03-systemes-differentiels-lineaires.tex
+++ b/chapter03-systemes-differentiels-lineaires.tex
@@ -926,7 +926,7 @@ en forme normale de Jordan.
 \begin{proof}[Démonstration du Théorème~\ref{thr:38}] 
   Pour $x \in V \setminus \{0\}$ on appelle 
   \begin{displaymath}
-    m_x = \min \{ i \colon N^ix = 0\}
+    m_x = \max \{ i \colon N^ix = 0\}
   \end{displaymath}
   la \emph{durée de vie} de $x$. 
   La séquence 


### PR DESCRIPTION
In the proof of thr:38, I changed the \min in the definition of durée de vie for a \max, as that is indeed the correct definition.