### PR TITLE
BK and eigen values relation + Name typo

### DIFF
--- a/TeX/chapter02-theoreme-spectral.tex
+++ b/TeX/chapter02-theoreme-spectral.tex
@@ -596,9 +596,9 @@ où $R$ est une matrice triangulaire supérieure dont les éléments diagonaux s
 \item Montrer la partie \eqref{eq:13} du théorème~\ref{thr:19}. 
 \item 
 Soit $A \in \R^{n \times n}$ une matrice symétrique avec les valeurs propres $\lambda_1 \geq \dots \geq \lambda_n$. 
-Soit $B_K$ une matrice comme décrite en dessus o\`u $|K| = k$ avec les valeurs propres  $\mu_1 \geq \dots  \geq \mu_{n-k}$. Pour $1 \leq i \leq k$, alors 
+Soit $B_K$ une matrice comme décrite en dessus o\`u $|K| = k$ avec les valeurs propres  $\mu_1 \geq \dots  \geq \mu_{k}$. Pour $1 \leq i \leq k$, alors 
 \begin{displaymath}
-  \lambda_i \geq  \mu_i \geq  \lambda_{i+k}.
+  \lambda_i \geq  \mu_i \geq  \lambda_{i+n-k}.
 \end{displaymath}
  
 \end{enumerate}

--- a/TeX/notes.tex
+++ b/TeX/notes.tex
@@ -189,7 +189,7 @@ Des corrections et modifications ont été implémentées par:
 \item Beatrice Serrurier
 \item Pablo Habib
 \item Vittorio Sandri
-\item Youssef Yamali
+\item Youssef Jamali
 \end{itemize}
 
 Le deuxième   chapitre est basé, en partie, sur les notes du cours de Daniel Kressner.  


### PR DESCRIPTION
It seems to me we defined BK as the matrix remaining when considering rows and columns of set K rather than removing them, this would also affect the inequality demanded to prove.